### PR TITLE
Better contrast between type variable and its members

### DIFF
--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -14,6 +14,7 @@
 "variable" = "#715ab1"
 "variable.builtin" = "#715ab1"
 "variable.parameter" = "#7590db"
+"variable.other.member" = "#002db3"
 "type" = "#6c3163"
 "type.builtin" = "#6c3163"
 "constructor" = { fg = "#4e3163", modifiers = ["bold"] }


### PR DESCRIPTION
Observe 'close' and 'open' members w.r.t type variable.

Before:
![image](https://github.com/rsj-ioki/helix/assets/68541057/60059258-0e6f-44c6-a367-3caa560d5262)

After:
![image](https://github.com/rsj-ioki/helix/assets/68541057/78d4d2ae-05ce-4343-9c96-9ed51f66020d)
